### PR TITLE
React/ React Native ZTM Section 07

### DIFF
--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -3,11 +3,18 @@ import {ReactComponent as CrwnLogo} from '../../assets/crown.svg'
 import './Navbar.scss'
 import {useContext} from 'react';
 import {UserContext} from '../../contexts/user'
+import {signOutUser} from '../../utils/firebase'
 
 const Navbar:React.FC = () => {
 
-  const {currentUser} = useContext(UserContext);
-  console.log(currentUser);
+  const {currentUser, setCurrentUser} = useContext(UserContext);
+
+  const handleSignout = async() => {
+    const res = await signOutUser();
+    console.log(res);
+    setCurrentUser(null);
+  }
+
 
   return (
     <>
@@ -17,7 +24,11 @@ const Navbar:React.FC = () => {
         </Link>
         <div className="nav-links-container">
           <Link className= 'nav-link' to='/shop'>SHOP</Link>
-          <Link className= 'nav-link' to='/signin'>SIGN IN</Link>
+          {currentUser ? (
+            <span className= 'nav-link' onClick= {()=> handleSignout()}>SIGN OUT</span>
+          ): (
+            <Link className= 'nav-link' to='/signin'>SIGN IN</Link>
+          )}
         </div>
       </div>
       <Outlet/>

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -1,8 +1,14 @@
 import {Outlet, Link} from 'react-router-dom';
 import {ReactComponent as CrwnLogo} from '../../assets/crown.svg'
 import './Navbar.scss'
+import {useContext} from 'react';
+import {UserContext} from '../../contexts/user'
 
 const Navbar:React.FC = () => {
+
+  const {currentUser} = useContext(UserContext);
+  console.log(currentUser);
+
   return (
     <>
       <div className="navigation">

--- a/src/components/signin/Signin.tsx
+++ b/src/components/signin/Signin.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useContext} from 'react';
 
 import FormInput from '../input/FormInput'
 import Button from '../button/Button'
@@ -7,6 +7,8 @@ import {
   signInAuthUserWithEmailAndPassword,
   signInWithGooglePopup,
 } from '../../utils/firebase'
+
+import {UserContext} from '../../contexts/user'
 
 import './Signin.scss';
 
@@ -19,20 +21,27 @@ const Signin = () => {
   const [formFields, setFormFields] = useState(defaultFormFields);
   const { email, password } = formFields;
 
+  const {setCurrentUser} = useContext(UserContext);
+
   const resetFormFields = () => {
     setFormFields(defaultFormFields);
   };
 
   const signInWithGoogle = async () => {
-    await signInWithGooglePopup();
+    const res= await signInWithGooglePopup();
+    // console.log(res);
   };
 
   const handleSubmit = async (event: any) => {
     event.preventDefault();
 
     try {
-      await signInAuthUserWithEmailAndPassword(email, password);
-      resetFormFields();
+      const res = await signInAuthUserWithEmailAndPassword(email, password);
+
+      if (res){
+        setCurrentUser(res.user);
+        resetFormFields();
+      }
     } catch (error) {
       console.log('user sign in failed', error);
     }

--- a/src/components/signup/Signup.tsx
+++ b/src/components/signup/Signup.tsx
@@ -1,8 +1,9 @@
-import React,{useState} from 'react'
+import React, {useState, useContext} from 'react'
 import {Field} from '../../../types/Types'
 import {createAuthUserFromEmailPassword, createUserDocumentFromAuth} from '../../utils/firebase'
 import Button from '../button/Button'
 import FormInput from '../input/FormInput'
+import {UserContext} from '../../contexts/user'
 
 const defaultFields:Field = {
   displayName: '',
@@ -19,7 +20,7 @@ const Signup:React.FC = () => {
   //doing it this way allows you to not create a state for each target values
   const {displayName, email, password, confirmPassword} = fields;
 
-  console.log(fields);
+  const {setCurrentUser} = useContext(UserContext);
 
     const resetFormFields = () => {
       setFields(defaultFields);
@@ -36,7 +37,9 @@ const Signup:React.FC = () => {
         //create user doc
         try{
           const res = await createAuthUserFromEmailPassword(email, password);
+
           if (res){
+            setCurrentUser(res.user);
             await createUserDocumentFromAuth(res.user, {displayName});
           }
           resetFormFields();

--- a/src/contexts/user.tsx
+++ b/src/contexts/user.tsx
@@ -1,0 +1,20 @@
+import React, {createContext, useState} from 'react'
+
+//as the actual value you want to access
+export const UserContext = createContext<any>({
+    currentUser: null,
+    setCurrentUser: ()=> null,
+})
+
+interface Props{
+    children: React.ReactNode
+}
+
+//the actual functional component
+export const UserProvider:React.FC<Props> = ({children}) => {
+
+    const [currentUser, setCurrentUser] = useState(null);
+    const value = {currentUser, setCurrentUser};
+    
+    return <UserContext.Provider value={value}>{children}</UserContext.Provider>
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ import {
   Route,
 } from "react-router-dom";
 import Login from './routes/Login';
+import {UserProvider} from './contexts/user'
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
@@ -42,7 +43,9 @@ const router = createBrowserRouter([
 
 root.render(
   <React.StrictMode>
+    <UserProvider>
     <RouterProvider router={router}/>
+    </UserProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Covers course material section-07: chapter 104-108

### Chapter 104: Need for Context
- How to leverage the user object at a higher level 
- Prop drilling: forcing the data from the top level app component to be passed down all the components until it reaches it’s destination component, the parents of the destination component may not need it at all but are forced to take in the data as prop in order to pass it down.
- React context allows us to create an external storage to store our data so we do not have to go through this tedious process of passing all the relevant data from the DOM
- State management allows us to access this state whenever and wherever we want

### Chapter 105: User Context

- In our application, when a user is signed in, we instead want to show a sign out button instead so that the user can sign out of their account
- We need a state to store if a user Is currently signed in or not 
- Created a folder and file of context, you can think of context as two different pieces; one being the literal storage itself to access the values, and UserProvider which wraps around the app component to allow us to use createContext
- Import React Context Provider inside the index.tsx , and wrap It around the component that you want to have access to the storage (wrap it around route provider)
- To use the react context inside the components, import it from react first, then import the setter function from the react context file
- Whenever the state inside of the react context updates, the component Is also re-rendered because the value has been updated

### Chapter 106: Re-rendering From Context 
- understand react re-render model with react context
- inside of signup, console.log out the word "hit"
- userprovider is wrapping app --> app contains components --> contains Signin, Signup component (however I don't think this architecture is true anymore due to react router v6 changes)
- the fact that you use anything from useContext will cause your functions inside of your components to be re-rendered
- it will only re-render the component if the state inside useContext is updated
- you do not want all of your components under the App to be hooked onto the useContext because all of the code before the return statement will be called if other components update the values inside of useContext, **TLDR; you only want the essential components to be using useContext** 

### Chapter 107: Signing out
- In Signin and Signout components, we imported useContext and UserContext(where we store all the values) and used the setter function to set the value of "currentUser" to the user object created from firebase response
- Navbar checks if the state of currentUser exists or not if it does and is occupied then we know the user is logged and and instead of "sign-in" display "sign-out"
- imported a new function from firebase auth to signout of account and modify the auth
- export const signOutUser = async () => await signOut(auth);
- binded the function to call when the button of singout is clicked and set currentUser back to null (initial state)

### Chapter 108: Teaching what you learn
- some recommendation stating you should help some people in the dev community further help you solidify your knowledge
